### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,9 +40,9 @@ Create empty database in PostgreSQL.
 git clone git@github.com:zubroide/gitpab.git
 cd gitpab
 composer install
+cp .env.example .env
 php artisan key:generate
 php artisan vendor:publish --provider="JeroenNoten\LaravelAdminLte\ServiceProvider" --tag=assets
-cp .env.example .env
 ```
 
 Edit environment variables in `.env`:


### PR DESCRIPTION
fix installation instructions. `php artisan key:generate` does not run when .env is not available:

```
$ php artisan key:generate

In KeyGenerateCommand.php line 96:
                                                                                                           
  file_get_contents(/home/cebe/dev/cebe.cc/gitpab/.env): failed to open stream: No such file or directory  
                                                                                                           
```